### PR TITLE
Update 1.11.0-missing-stdint.patch

### DIFF
--- a/dev-libs/weston/files/1.11.0-missing-stdint.patch
+++ b/dev-libs/weston/files/1.11.0-missing-stdint.patch
@@ -9,3 +9,6 @@ diff -Naur weston-1.11.0.orig/shared/xalloc.h weston-1.11.0/shared/xalloc.h
  #include <stdlib.h>
  #include <string.h>
  
+ #weston-launch
+#include <err.h>
+#replace standart gclibc <error.h> which not supported in musl witn err.h


### PR DESCRIPTION
src/weston-launch.c:36:19: fatal error: error.h: No such file or directory
# include <error.h>

```
               ^
```

compilation terminated.
