### PR TITLE
dev-libs/glib-2.46.2 - fix g_strerror() on non-glibc

### DIFF
--- a/dev-libs/glib/files/glib-2.46.2-fix-gstrerror-on-non-glibc.patch
+++ b/dev-libs/glib/files/glib-2.46.2-fix-gstrerror-on-non-glibc.patch
@@ -1,0 +1,30 @@
+From feb4fb2842ef123b16b0cdf8d50be192e30862be Mon Sep 17 00:00:00 2001
+From: Dan Winship <danw@gnome.org>
+Date: Mon, 16 Nov 2015 16:57:38 -0500
+Subject: Fix g_strerror() on non-glibc
+
+When using one of the codepaths that copies the error string into buf,
+make sure the string gets strdup() afterward.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=758194
+---
+ glib/gstrfuncs.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/glib/gstrfuncs.c b/glib/gstrfuncs.c
+index 6712a64..0e2498f 100644
+--- a/glib/gstrfuncs.c
++++ b/glib/gstrfuncs.c
+@@ -1293,6 +1293,8 @@ g_strerror (gint errnum)
+           if (error)
+             g_print ("%s\n", error->message);
+         }
++      else if (msg == (const gchar *)buf)
++        msg = g_strdup (buf);
+ 
+       g_hash_table_insert (errors, GINT_TO_POINTER (errnum), (char *) msg);
+     }
+-- 
+cgit v0.12
+
+

--- a/dev-libs/glib/glib-2.46.2-r3.ebuild
+++ b/dev-libs/glib/glib-2.46.2-r3.ebuild
@@ -153,6 +153,9 @@ src_prepare() {
 	# crash in Firefox when choosing default application, fixed in 2.48.1; bug #577686
 	epatch "${FILESDIR}"/${PN}-2.48.0-GContextSpecificGroup.patch
 
+	# fixes https://bugzilla.gnome.org/show_bug.cgi?id=758194
+	epatch "${FILESDIR}"/${PN}-2.46.2-fix-gstrerror-on-non-glibc.patch
+
 	# leave python shebang alone
 	sed -e '/${PYTHON}/d' \
 		-i glib/Makefile.{am,in} || die


### PR DESCRIPTION
there is an upstream bugreport --> https://bugzilla.gnome.org/show_bug.cgi?id=758194 

P.S. for an unknown reason the Manifest file I created for the edited ebuild does not differ at all, as it does include the distfiles only. This seems to be okay? 
